### PR TITLE
Add support alternative CDN from Yandex Metrika

### DIFF
--- a/src/config-factories.ts
+++ b/src/config-factories.ts
@@ -78,7 +78,15 @@ export function insertMetrika(counterConfigs: YandexCounterConfig[]) {
   const s = document.createElement('script');
   s.type = 'text/javascript';
   s.async = true;
-  s.src = 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js';
+
+  const alternative = counterConfigs.find(config => config.alternative);
+
+  if (alternative) {
+    s.src = 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js';
+  } else {
+    s.src = 'https://mc.yandex.ru/metrika/tag.js';
+  }
+
   const insetScriptTag = () => n.parentNode.insertBefore(s, n);
 
   if ((window as any).opera === '[object Opera]') {

--- a/src/config-factories.ts
+++ b/src/config-factories.ts
@@ -78,7 +78,7 @@ export function insertMetrika(counterConfigs: YandexCounterConfig[]) {
   const s = document.createElement('script');
   s.type = 'text/javascript';
   s.async = true;
-  s.src = 'https://mc.yandex.ru/metrika/tag.js';
+  s.src = 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js';
   const insetScriptTag = () => n.parentNode.insertBefore(s, n);
 
   if ((window as any).opera === '[object Opera]') {

--- a/src/metrika.config.ts
+++ b/src/metrika.config.ts
@@ -16,6 +16,7 @@ export interface CounterConfig {
   ut?: string;
   ecommerce?: string;
   triggerEvent?: boolean;
+  alternative?: boolean;
 }
 
 export class YandexCounterConfig  implements CounterConfig {
@@ -29,4 +30,5 @@ export class YandexCounterConfig  implements CounterConfig {
   ut = 'noindex';
   ecommerce?: string;
   triggerEvent?: boolean;
+  alternative?: boolean;
 }


### PR DESCRIPTION
This is necessary for countries in which Yandex does not work. For example, in Ukraine.