### PR TITLE
Update ng-yandex-metrika.service.ts

### DIFF
--- a/projects/ng-yandex-metrika/src/lib/ng-yandex-metrika.service.ts
+++ b/projects/ng-yandex-metrika/src/lib/ng-yandex-metrika.service.ts
@@ -100,7 +100,7 @@ export class Metrika {
   async params(params: any, counterPosition?: number): Promise<any> {
     try {
       const counter = await this.counterIsLoaded(counterPosition);
-      counter.userParams(params);
+      counter.params(params);
       return {params, counterPosition};
     } catch (error) {
       console.warn('Counter is still loading');


### PR DESCRIPTION
При использовании метода params данные отправляются в параметры посетителей, а должны в параметры визита.
https://yandex.ru/support/metrica/objects/params-method.html